### PR TITLE
Add flag for config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,15 @@ You can optionally provide the `sentries` array to also monitor the sentries via
 See [here](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) for how to create a webhook for a discord channel.
 
 Begin monitoring with:
+
 ```bash
-halflife monitor
+half-life monitor
+```
+
+By default, `half-life monitor` will look for `config.yaml` in the current working directory. To specify a different config file path, use the `--file`/`-f` flag:
+
+```bash
+half-life monitor -f ~/config.yaml
 ```
 
 When a validator is first added to `config.yaml` and halflife is started, a status message will be created in the discord channel and the ID of that message will be added to `config.yaml`. Pin this message so that the channel's pinned messages can act as a dashboard to see the realtime status of the validators.

--- a/cmd/NotificationService.go
+++ b/cmd/NotificationService.go
@@ -7,5 +7,5 @@ type NotificationService interface {
 	SendValidatorAlertNotification(config *HalfLifeConfig, vm *ValidatorMonitor, stats ValidatorStats, alertNotification *ValidatorAlertNotification)
 
 	// update (or create) realtime status for validator
-	UpdateValidatorRealtimeStatus(config *HalfLifeConfig, vm *ValidatorMonitor, stats ValidatorStats, writeConfigMutex *sync.Mutex)
+	UpdateValidatorRealtimeStatus(configFile string, config *HalfLifeConfig, vm *ValidatorMonitor, stats ValidatorStats, writeConfigMutex *sync.Mutex)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -119,7 +119,7 @@ type ValidatorMonitor struct {
 	Sentries               *[]Sentry `yaml:"sentries"`
 }
 
-func saveConfig(config *HalfLifeConfig, writeConfigMutex *sync.Mutex) {
+func saveConfig(configFile string, config *HalfLifeConfig, writeConfigMutex *sync.Mutex) {
 	writeConfigMutex.Lock()
 	defer writeConfigMutex.Unlock()
 
@@ -128,7 +128,7 @@ func saveConfig(config *HalfLifeConfig, writeConfigMutex *sync.Mutex) {
 		fmt.Printf("Error during config yaml marshal %v\n", err)
 	}
 
-	err = os.WriteFile(configFilePath, yamlBytes, 0644)
+	err = os.WriteFile(configFile, yamlBytes, 0644)
 	if err != nil {
 		fmt.Printf("Error saving config yaml %v\n", err)
 	}

--- a/cmd/discord.go
+++ b/cmd/discord.go
@@ -111,6 +111,7 @@ func getCurrentStatsEmbed(stats ValidatorStats, vm *ValidatorMonitor) discord.Em
 
 // implements NotificationService interface
 func (service *DiscordNotificationService) UpdateValidatorRealtimeStatus(
+	configFile string,
 	config *HalfLifeConfig,
 	vm *ValidatorMonitor,
 	stats ValidatorStats,
@@ -138,7 +139,7 @@ func (service *DiscordNotificationService) UpdateValidatorRealtimeStatus(
 		messageID := string(message.ID)
 		vm.DiscordStatusMessageID = &messageID
 		fmt.Printf("Saved message ID: %s\n", messageID)
-		saveConfig(config, writeConfigMutex)
+		saveConfig(configFile, config, writeConfigMutex)
 	}
 }
 

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -15,7 +15,8 @@ var monitorCmd = &cobra.Command{
 	Short: "Daemon to monitor validators",
 	Long:  "Monitors validators and pushes alerts to Discord using the configuration in config.yaml",
 	Run: func(cmd *cobra.Command, args []string) {
-		dat, err := os.ReadFile(configFilePath)
+		configFile, _ := cmd.Flags().GetString("file")
+		dat, err := os.ReadFile(configFile)
 		if err != nil {
 			log.Fatalf("Error reading config.yaml: %v", err)
 		}
@@ -48,9 +49,9 @@ var monitorCmd = &cobra.Command{
 		alertState := make(map[string]*ValidatorAlertState)
 		for i, vm := range config.Validators {
 			if i == len(config.Validators)-1 {
-				runMonitor(notificationService, &alertState, &config, vm, &writeConfigMutex)
+				runMonitor(notificationService, &alertState, configFile, &config, vm, &writeConfigMutex)
 			} else {
-				go runMonitor(notificationService, &alertState, &config, vm, &writeConfigMutex)
+				go runMonitor(notificationService, &alertState, configFile, &config, vm, &writeConfigMutex)
 			}
 		}
 	},
@@ -58,4 +59,5 @@ var monitorCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(monitorCmd)
+	monitorCmd.Flags().StringP("file", "f", configFilePath, "File path to config yaml")
 }

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -175,6 +175,7 @@ func monitorSentries(
 func runMonitor(
 	notificationService NotificationService,
 	alertState *map[string]*ValidatorAlertState,
+	configFile string,
 	config *HalfLifeConfig,
 	vm *ValidatorMonitor,
 	writeConfigMutex *sync.Mutex,
@@ -260,7 +261,7 @@ func runMonitor(
 			notificationService.SendValidatorAlertNotification(config, vm, stats, notification)
 		}
 
-		notificationService.UpdateValidatorRealtimeStatus(config, vm, stats, writeConfigMutex)
+		notificationService.UpdateValidatorRealtimeStatus(configFile, config, vm, stats, writeConfigMutex)
 
 		time.Sleep(30 * time.Second)
 	}


### PR DESCRIPTION
Adds `-f`/`--file` flag to `monitor` command to provide a custom config.yaml filepath.

Resolves #1 