### PR TITLE
Make all config.AlertTypes ignorable via yaml configuration

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,3 +1,8 @@
+# Optionally uncomment to ignore specific alerts
+#alerts:
+#  ignore-alerts:
+#    - alertTypeMissedRecentBlocks
+
 notifications:
   service: discord
   discord:

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.17
 require (
 	github.com/DisgoOrg/disgo v0.7.2
 	github.com/DisgoOrg/snowflake v1.0.4
+	github.com/Workiva/go-datastructures v1.0.52
 	github.com/cosmos/cosmos-sdk v0.44.5
 	github.com/spf13/cobra v1.3.0
 	github.com/tendermint/tendermint v0.34.14
+	google.golang.org/grpc v1.42.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -99,7 +101,6 @@ require (
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
-	google.golang.org/grpc v1.42.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect


### PR DESCRIPTION
I love this tool, but we actually don't want to see individual block misses as it's too noisy. 

It makes sense that people should be able to opt out of alerting on any alert type so this PR does this.

You can now add this to your config.yaml for example to ignore missed block alerts:
```
alerts:
  ignore-alerts:
    - alertTypeMissedRecentBlocks
```

This `alerts` config section can later be used for allowing custom tweaking of the alert thresholds like people have wanted [here](https://github.com/strangelove-ventures/half-life/issues/4).


PR Details:
* Changes AlertType enum from int8 -> string so we can easily parse the yaml config string to the ignore the alert.
* Makes a new `IgnorableError` interface so that people adding new validator errors in `monitorValidator()` don't need to remember to add the `config.AlertType` mapping, as it will be a compiler error until they do so.
* Filter out the configured ignored errors before sending them as alerts (I did this at this section because there is exponential back off / retry related logic for a couple of the errors and I wanted to preserve those flows even if you were ignoring the alerts for those errors)