### PR TITLE
ChainHaltError shouldn't be a warning

### DIFF
--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -426,7 +426,7 @@ func getAlertNotification(
 			stats.RPCError = true
 		case *ChainHaltError:
 			fmt.Printf("found chain halt error\n")
-			handleGenericAlert(err, alertTypeHalt, alertLevelCritical)
+			handleGenericAlert(err, alertTypeHalt, alertLevelHigh)
 			stats.RPCError = true
 		case *BlockFetchError:
 			handleGenericAlert(err, alertTypeBlockFetch, alertLevelWarning)

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -426,7 +426,7 @@ func getAlertNotification(
 			stats.RPCError = true
 		case *ChainHaltError:
 			fmt.Printf("found chain halt error\n")
-			handleGenericAlert(err, alertTypeHalt, alertLevelWarning)
+			handleGenericAlert(err, alertTypeHalt, alertLevelCritical)
 			stats.RPCError = true
 		case *BlockFetchError:
 			handleGenericAlert(err, alertTypeBlockFetch, alertLevelWarning)


### PR DESCRIPTION
ChainHalt is one of the more severe conditions out there for both validator and fullnode monitoring, I think it should alert mention people.