### PR TITLE
Make grpc error threshold configurable per deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,32 +16,9 @@ Discord messages are created in the configured webhook channel for:
 
 ## Quick start
 
-### Install Go
+### Download
 
-Go is necessary in order to install `halflife`.
-
-```
-# install
-wget https://golang.org/dl/go1.18.2.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
-
-# source go
-cat <<EOF >> ~/.profile
-export GOROOT=/usr/local/go
-export GOPATH=$HOME/go
-export GO111MODULE=on
-export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
-EOF
-source ~/.profile
-go version
-```
-
-### Install halflife binary
-
-```
-cd ~/half-life
-go install
-```
+Binaries are available on the [releases](https://github.com/strangelove-ventures/half-life/releases) page.
 
 ### Setup config.yaml
 
@@ -49,6 +26,7 @@ Copy `config.yaml.example` to `config.yaml` and populate with your discord and v
 You can optionally provide the `sentries` array to also monitor the sentries via grpc.
 `rpc-retries` can optionally be provided to override the default of 5 RPC retries before alerting, useful for congested RPC servers.
 `fullnode` can be set to `true` to only monitor reachable and out of sync for the provided `sentries`. `address` is not required when `fullnode` is `true`.
+`sentry-grpc-error-threshold` can be provided for each validator to tune how many grpc errors are detected (roughtly 30 seconds between checks) before issuing a notification.
 
 See [here](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) for how to create a webhook for a discord channel.
 
@@ -89,3 +67,31 @@ For high and critical errors, the configured discord user IDs will be tagged
 
 ![Screenshot from 2022-02-16 11-38-00](https://user-images.githubusercontent.com/6722152/154333667-af823075-73fc-4d41-97ce-40432f3450ac.png)
 
+## Build from source
+
+### Install Go
+
+Go is necessary in order to build `half-life` from source.
+
+```
+# install
+wget https://golang.org/dl/go1.18.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
+
+# source go
+cat <<EOF >> ~/.profile
+export GOROOT=/usr/local/go
+export GOPATH=$HOME/go
+export GO111MODULE=on
+export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+EOF
+source ~/.profile
+go version
+```
+
+### Install halflife binary
+
+```
+cd ~/half-life
+go install
+```

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -167,15 +167,16 @@ type Sentry struct {
 }
 
 type ValidatorMonitor struct {
-	Name                   string    `yaml:"name"`
-	RPC                    string    `yaml:"rpc"`
-	FullNode               bool      `yaml:"fullnode"`
-	Address                string    `yaml:"address"`
-	ChainID                string    `yaml:"chain-id"`
-	DiscordStatusMessageID *string   `yaml:"discord-status-message-id"`
-	RPCRetries             *int      `yaml:"rpc-retries"`
-	MissedBlocksThreshold  *int64    `yaml:"missed-blocks-threshold"`
-	Sentries               *[]Sentry `yaml:"sentries"`
+	Name                     string    `yaml:"name"`
+	RPC                      string    `yaml:"rpc"`
+	FullNode                 bool      `yaml:"fullnode"`
+	Address                  string    `yaml:"address"`
+	ChainID                  string    `yaml:"chain-id"`
+	DiscordStatusMessageID   *string   `yaml:"discord-status-message-id"`
+	RPCRetries               *int      `yaml:"rpc-retries"`
+	MissedBlocksThreshold    *int64    `yaml:"missed-blocks-threshold"`
+	SentryGRPCErrorThreshold *int64    `yaml:"sentry-grpc-error-threshold"`
+	Sentries                 *[]Sentry `yaml:"sentries"`
 }
 
 func saveConfig(configFile string, config *HalfLifeConfig, writeConfigMutex *sync.Mutex) {

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -475,7 +475,13 @@ func getAlertNotification(
 			foundSentryGRPCErrors = append(foundSentryGRPCErrors, sentryName)
 			if alertState.SentryGRPCErrorCounts[sentryName]%notifyEvery == 0 || alertState.SentryGRPCErrorCounts[sentryName] == sentryGRPCErrorNotifyThreshold {
 				addAlert(err)
-				if alertState.SentryGRPCErrorCounts[sentryName] >= sentryGRPCErrorNotifyThreshold {
+				var threshold int64
+				if vm.SentryGRPCErrorThreshold != nil {
+					threshold = *vm.SentryGRPCErrorThreshold
+				} else {
+					threshold = sentryGRPCErrorNotifyThreshold
+				}
+				if alertState.SentryGRPCErrorCounts[sentryName] >= threshold {
 					setAlertLevel(alertLevelHigh)
 				} else {
 					setAlertLevel(alertLevelWarning)

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -577,7 +577,13 @@ func getAlertNotification(
 			}
 		}
 		if !sentryFound && alertState.SentryGRPCErrorCounts[sentryName] > 0 {
-			if alertState.SentryGRPCErrorCounts[sentryName] > sentryGRPCErrorNotifyThreshold {
+			var threshold int64
+			if vm.SentryGRPCErrorThreshold != nil {
+				threshold = *vm.SentryGRPCErrorThreshold
+			} else {
+				threshold = sentryGRPCErrorNotifyThreshold
+			}
+			if alertState.SentryGRPCErrorCounts[sentryName] > threshold {
 				alertNotification.NotifyForClear = true
 			}
 			alertState.SentryGRPCErrorCounts[sentryName] = 0


### PR DESCRIPTION
For nodes that crash periodically, e.g. evmos mainnet v8.1.0, the notification spam is obnoxious. This allows tuning the grpc error notification threshold so that only after the configured number of consecutive grpc errors will a notification be sent. For example, with `sentry-grpc-error-threshold: 3`, it will only notify after 3 times that it polls and detects a GRPC error  (30 seconds each poll roughly so only after ~1.5 minutes of grpc errors will a notification be triggered.)

Warning messages will still be posted in the channel, but they will not tag the configured user ids until the threshold is reached.

Closes #16